### PR TITLE
Added feature to enable/disable htmlentity operations

### DIFF
--- a/HtmlDocument.php
+++ b/HtmlDocument.php
@@ -34,6 +34,7 @@ class HtmlDocument
 	public $lowercase = false;
 	public $original_size;
 	public $size;
+	public $enable_htmlentity_operations;
 
 	protected $pos;
 	protected $doc;
@@ -113,8 +114,11 @@ class HtmlDocument
 		$stripRN = true,
 		$defaultBRText = DEFAULT_BR_TEXT,
 		$defaultSpanText = DEFAULT_SPAN_TEXT,
-		$options = 0)
+		$options = 0,
+		$enable_htmlentity_operations = true)
 	{
+		$this->enable_htmlentity_operations = $enable_htmlentity_operations;
+
 		if ($str) {
 			if (preg_match('/^http:\/\//i', $str) || strlen($str) <= PHP_MAXPATHLEN && is_file($str)) {
 				$this->loadFile($str);
@@ -266,11 +270,17 @@ class HtmlDocument
 
 					$node = new HtmlNode($this);
 					++$this->cursor;
-					$node->_[HtmlNode::HDOM_INFO_TEXT] = html_entity_decode(
-						$this->restore_noise($content),
-						ENT_QUOTES | ENT_HTML5,
-						$this->_target_charset
-					);
+
+					if ($this->enable_htmlentity_operations) {
+						$node->_[HtmlNode::HDOM_INFO_TEXT] = html_entity_decode(
+							$this->restore_noise($content),
+							ENT_QUOTES | ENT_HTML5,
+							$this->_target_charset
+						);
+					} else {
+						$node->_[HtmlNode::HDOM_INFO_TEXT] = $this->restore_noise($content);
+					}
+
 					$this->link_nodes($node, false);
 
 				}
@@ -789,11 +799,15 @@ class HtmlDocument
 			}
 
 			if ($innertext !== '') {
-				$node->_[HtmlNode::HDOM_INFO_INNER] = html_entity_decode(
-					$this->restore_noise($innertext),
-					ENT_QUOTES | ENT_HTML5,
-					$this->_target_charset
-				);
+				if ($this->enable_htmlentity_operations) {
+					$node->_[HtmlNode::HDOM_INFO_INNER] = html_entity_decode(
+						$this->restore_noise($innertext),
+						ENT_QUOTES | ENT_HTML5,
+						$this->_target_charset
+					);
+				} else {
+					$node->_[HtmlNode::HDOM_INFO_INNER] = $this->restore_noise($innertext);
+				}
 			}
 
 			$this->parent = $node;
@@ -846,11 +860,15 @@ class HtmlDocument
 			if ($quote_type !== HtmlNode::HDOM_QUOTE_DOUBLE) {
 				$node->_[HtmlNode::HDOM_INFO_QUOTE][$name] = $quote_type;
 			}
-			$node->attr[$name] = html_entity_decode(
-				$value,
-				ENT_QUOTES | ENT_HTML5,
-				$this->_target_charset
-			);
+			if ($this->enable_htmlentity_operations) {
+				$node->attr[$name] = html_entity_decode(
+					$value,
+					ENT_QUOTES | ENT_HTML5,
+					$this->_target_charset
+				);
+			} else {
+				$node->attr[$name] = $value;
+			}
 		}
 	}
 

--- a/HtmlNode.php
+++ b/HtmlNode.php
@@ -295,7 +295,11 @@ class HtmlNode
 				} else {
 					$charset = DEFAULT_TARGET_CHARSET;
 				}
-				$ret .= htmlentities($this->_[self::HDOM_INFO_INNER], ENT_QUOTES | ENT_SUBSTITUTE, $charset);
+				if ($this->dom->enable_htmlentity_operations) {
+					$ret .= htmlentities($this->_[self::HDOM_INFO_INNER], ENT_QUOTES | ENT_SUBSTITUTE, $charset);
+				} else {
+					$ret .= $this->_[self::HDOM_INFO_INNER];
+				}
 			}
 		}
 
@@ -473,12 +477,16 @@ class HtmlNode
 						$quote = '"';
 				}
 
+				if ($this->dom->enable_htmlentity_operations) {
+					$val = htmlentities($val, ENT_COMPAT, $this->dom->target_charset);
+				}
+
 				$ret .= $key
 				. (isset($this->_[self::HDOM_INFO_SPACE][$key]) ? $this->_[self::HDOM_INFO_SPACE][$key][1] : '')
 				. '='
 				. (isset($this->_[self::HDOM_INFO_SPACE][$key]) ? $this->_[self::HDOM_INFO_SPACE][$key][2] : '')
 				. $quote
-				. htmlentities($val, ENT_COMPAT, $this->dom->target_charset)
+				. $val
 				. $quote;
 			}
 		}

--- a/simple_html_dom.php
+++ b/simple_html_dom.php
@@ -91,7 +91,8 @@ function file_get_html(
 	$target_charset = DEFAULT_TARGET_CHARSET,
 	$stripRN = true,
 	$defaultBRText = DEFAULT_BR_TEXT,
-	$defaultSpanText = DEFAULT_SPAN_TEXT)
+	$defaultSpanText = DEFAULT_SPAN_TEXT,
+	$enable_htmlentity_operations = true)
 {
 	if($maxLen <= 0) { $maxLen = MAX_FILE_SIZE; }
 
@@ -102,7 +103,9 @@ function file_get_html(
 		$target_charset,
 		$stripRN,
 		$defaultBRText,
-		$defaultSpanText
+		$defaultSpanText,
+		0,
+		$enable_htmlentity_operations
 	);
 
 	$contents = file_get_contents(
@@ -128,7 +131,8 @@ function str_get_html(
 	$target_charset = DEFAULT_TARGET_CHARSET,
 	$stripRN = true,
 	$defaultBRText = DEFAULT_BR_TEXT,
-	$defaultSpanText = DEFAULT_SPAN_TEXT)
+	$defaultSpanText = DEFAULT_SPAN_TEXT,
+	$enable_htmlentity_operations = true)
 {
 	$dom = new simple_html_dom(
 		null,
@@ -137,7 +141,9 @@ function str_get_html(
 		$target_charset,
 		$stripRN,
 		$defaultBRText,
-		$defaultSpanText
+		$defaultSpanText,
+		0,
+		$enable_htmlentity_operations
 	);
 
 	if (empty($str) || strlen($str) > MAX_FILE_SIZE) {


### PR DESCRIPTION
This library changes the original document, like this(screenshot): http://prntscr.com/hqTET5oRmhQ4

When a WordPress-generated HTML document(which is already escaped) is passed through this library, it results in changed output which is unexpected and opens the door for future bugs. This PR prevents that.

Here I've added a new feature/option to enable/disable `htmlentity` operations. By default, it is enabled, like before. But when using it as `disabled`, it will not perform any `htmlentity` operations and thus will not change the original document.

@DavidAnderson684 